### PR TITLE
Blender 2.78: Add missing versions

### DIFF
--- a/gui/blender.xml
+++ b/gui/blender.xml
@@ -237,6 +237,38 @@
       <manifest-digest sha1new="1e83586a27b41999611b97ecac29698412df2ade" sha256="e5542c995828517ad0323767b52389a1215855bc2ec449a8cba31c49bd59a2c5" sha256new="4VKCZGKYFBIXVUBSG5T3KI4JUEQVQVN4F3CETKGLUMOETPKZULCQ"/>
       <archive extract="blender-2.78a-linux-glibc211-i686" href="http://download.blender.org/release/Blender2.78/blender-2.78a-linux-glibc211-i686.tar.bz2" size="120179335" type="application/x-bzip-compressed-tar"/>
     </implementation>
+    <implementation arch="Windows-i486" id="sha1new=88f4a46c45cefc36b120bc3f5a0f483e08ca9c06" main="blender.exe" released="2017-02-08" stability="stable" version="2.78-2">
+      <manifest-digest sha256new="CB2QKRE34ZFEC3N64UUQ7ZUZKLEA5UZQQW2KVNITXSGWMINVGM5Q"/>
+      <archive extract="blender-2.78b-windows32" href="https://download.blender.org/release/Blender2.78/blender-2.78b-windows32.zip" size="95284181" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6f907799bc8e331c7fe9e63748c258cddc06d422" main="blender.exe" released="2017-02-08" stability="stable" version="2.78-2">
+      <manifest-digest sha256new="EUX3BCFXL4WIAO2PI6A46ZRVWUJJ6ARWHVYI3HLV4M2TNTEEXU5Q"/>
+      <archive extract="blender-2.78b-windows64" href="https://download.blender.org/release/Blender2.78/blender-2.78b-windows64.zip" size="116133812" type="application/zip"/>
+    </implementation>
+<implementation arch="Linux-i686" id="sha1new=e3ae22cfa5c42efeb3a437f9a2354f394ef51c25" main="blender" released="2017-02-08" stability="stable" version="2.78-2">
+      <manifest-digest sha256new="ZJQZWXJI5B746LYDP4XYUXFZ4O5DRQNRY2JIKZLNZI6TDB6D5I5Q"/>
+      <archive extract="blender-2.78b-linux-glibc219-i686" href="https://download.blender.org/release/Blender2.78/blender-2.78b-linux-glibc219-i686.tar.bz2" size="136399318" type="application/x-bzip-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=3a7f0f3fb7bb19682d075ee771fe0c09403d625a" main="blender" released="2017-02-08" stability="stable" version="2.78-2">
+      <manifest-digest sha256new="HAE3BRC6DNLOXCM4KV7HKFTUWWMZ4FUZRBWZOVW672TKCEUNCQTA"/>
+      <archive extract="blender-2.78b-linux-glibc219-x86_64" href="https://download.blender.org/release/Blender2.78/blender-2.78b-linux-glibc219-x86_64.tar.bz2" size="139859335" type="application/x-bzip-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=4abce30f5372a272448d6625eeeed1e027dcd736" main="blender.exe" released="2017-02-26" stability="stable" version="2.78-3">
+      <manifest-digest sha256new="PJ72NEIUOXYP4VXDNKDETDSVZ4YNVGNWXLGPAWSDSWOFPBW4MB6Q"/>
+      <archive extract="blender-2.78c-windows32" href="https://download.blender.org/release/Blender2.78/blender-2.78c-windows32.zip" size="95269105" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=b0b69692d0d25fa14fd75dc5f439708916c92059" main="blender.exe" released="2017-02-26" stability="stable" version="2.78-3">
+      <manifest-digest sha256new="HS5ASA4Q734VNJLUHZGHUDBBMC4WF2DFXIG655BPNMDRYAE4ZSHA"/>
+      <archive extract="blender-2.78c-windows64" href="https://download.blender.org/release/Blender2.78/blender-2.78c-windows64.zip" size="116121117" type="application/zip"/>
+    </implementation>
+<implementation arch="Linux-i686" id="sha1new=18608929b408cc3b3ebe070b2cd6adabd13731e3" main="blender" released="2017-02-26" stability="stable" version="2.78-3">
+      <manifest-digest sha256new="RU4EGLUUBN4YGG6HHWMWB6QYM7ELU2BCTSZQ4U4VO3FGV3BNPEAQ"/>
+      <archive extract="blender-2.78c-linux-glibc219-i686" href="https://download.blender.org/release/Blender2.78/blender-2.78c-linux-glibc219-i686.tar.bz2" size="128808474" type="application/x-bzip-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=b7bb16cb459b717ddb37c8f1d3dbc25fc9d8499a" main="blender" released="2017-02-26" stability="stable" version="2.78-3">
+      <manifest-digest sha256new="CP2TMALE73FYYJRSBRWQQEHNLUB3FAQFPNYEWTADNOND3JPKKNQA"/>
+      <archive extract="blender-2.78c-linux-glibc219-x86_64" href="https://download.blender.org/release/Blender2.78/blender-2.78c-linux-glibc219-x86_64.tar.bz2" size="133974164" type="application/x-bzip-compressed-tar"/>
+    </implementation>
     <implementation arch="Windows-x86_64" id="sha1new=497e4fd86a5388269f53365a5f78f436af1d3bbe" main="blender.exe" released="2020-02-14" stability="stable" version="2.82">
       <manifest-digest sha256new="7ALC3RA2H5NF3C32TBNMRYOTDRGKAGZ5QDCSZKOPJ6H7PNBW4GKQ"/>
       <archive extract="blender-2.82-windows64" href="https://download.blender.org/release/Blender2.82/blender-2.82-windows64.zip" size="156630901" type="application/zip"/>


### PR DESCRIPTION
- Blender 2.78b
- Blender 2.78c