### PR TITLE
Add Byacc

### DIFF
--- a/devel/byacc.xml
+++ b/devel/byacc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
-<interface uri="http://repo.roscidus.com/devel/byacc.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+<interface uri="http://repo.roscidus.com/devel/byacc" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
   <name>BYacc</name>
   <summary xml:lang="en">Yacc SPECS Yacc: LALR(1) parser generator</summary>
   <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>

--- a/devel/byacc.xml
+++ b/devel/byacc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
-<interface uri="http://repo.roscidus.com/devel/byacc" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+<interface uri="https://apps.0install.net/devel/byacc.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
   <name>BYacc</name>
   <summary xml:lang="en">Yacc SPECS Yacc: LALR(1) parser generator</summary>
   <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>

--- a/devel/byacc.xml
+++ b/devel/byacc.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://repo.roscidus.com/devel/byacc.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>BYacc</name>
+  <summary xml:lang="en">Yacc SPECS Yacc: LALR(1) parser generator</summary>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.png" type="image/png"/>
+  <category>Development</category>
+  <homepage>http://gnuwin32.sourceforge.net/packages/byacc.htm</homepage>
+  <needs-terminal/>
+  <implementation arch="Windows-*" id="sha1new=3020e85c89793acc1eb86b40219406991a388699" license="Public Domain" released="2003-10-04" version="1.9-1">
+    <command name="run" path="bin/yacc.exe"/>
+    <manifest-digest sha256new="P5VGQOFU5MFWFZ5ICY6V2FB5DPED5JRMP3M3XZJW3YG2DWHXS76A"/>
+    <archive href="https://sourceforge.net/projects/gnuwin32/files/byacc/1.9-1/byacc-1.9-1-bin.zip" size="49414" type="application/zip"/>
+  </implementation>
+  <entry-point binary-name="yacc" command="run">
+    <needs-terminal/>
+  </entry-point>
+</interface>

--- a/devel/byacc.xml
+++ b/devel/byacc.xml
@@ -3,8 +3,8 @@
 <interface uri="https://apps.0install.net/devel/byacc.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
   <name>BYacc</name>
   <summary xml:lang="en">Yacc SPECS Yacc: LALR(1) parser generator</summary>
-  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>
-  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.png" type="image/png"/>
+  <icon href="https://raw.githubusercontent.com/0install/apps/master/utils/gnu.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/apps/master/utils/gnu.png" type="image/png"/>
   <category>Development</category>
   <homepage>http://gnuwin32.sourceforge.net/packages/byacc.htm</homepage>
   <needs-terminal/>


### PR DESCRIPTION
add gnuwin32 package for byacc
berkley byacc

this is a broadly supported package with 137 packages across 91 repositories listed on Rep

part of 0install/0install.de-feeds#3

moved from https://github.com/0install/repo.roscidus.com/pull/159