### PR TITLE
Add Help2man

### DIFF
--- a/utils/help2man.xml
+++ b/utils/help2man.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
-<interface uri="http://repo.roscidus.com/utils/help2man" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+<interface uri="https://apps.0install.net/utils/help2man.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
   <name>Help2Man</name>
   <summary xml:lang="en">Help2Man: generate man page from help text of program</summary>
   <homepage>http://gnuwin32.sourceforge.net/packages/help2man.htm</homepage>
   <implementation arch="Windows-*" id="sha1new=21b11641e79283ad42b7d8479203c8e4d3c947d9" langs="fr pl" license="GPL v2 (GNU General Public License)" released="2005-04-24" version="1.35.1">
-    <requires interface="http://repo.roscidus.com/devel/gettext">
+    <requires interface="https://apps.0install.net/devel/gettext.xml">
       <environment insert="bin" name="PATH"/>
     </requires>
     <command name="run" path="bin\help2man">
-      <runner interface="http://repo.roscidus.com/perl/perl">
+      <runner interface="https://apps.0install.net/perl/perl.xml">
         <arg>-w</arg>
       </runner>
     </command>

--- a/utils/help2man.xml
+++ b/utils/help2man.xml
@@ -4,7 +4,7 @@
   <name>Help2Man</name>
   <summary xml:lang="en">Help2Man: generate man page from help text of program</summary>
   <homepage>http://gnuwin32.sourceforge.net/packages/help2man.htm</homepage>
-  <implementation arch="Windows-*" id="sha1new=21b11641e79283ad42b7d8479203c8e4d3c947d9" langs="fr pl" license="GPL v2 (GNU General Public License)" released="2005-04-24" version="1.35.1">
+  <implementation id="sha1new=21b11641e79283ad42b7d8479203c8e4d3c947d9" langs="fr pl" license="GPL v2 (GNU General Public License)" released="2005-04-24" version="1.35.1">
     <requires interface="https://apps.0install.net/devel/gettext.xml">
       <environment insert="bin" name="PATH"/>
     </requires>

--- a/utils/help2man.xml
+++ b/utils/help2man.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://repo.roscidus.com/utils/help2man" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Help2Man</name>
+  <summary xml:lang="en">Help2Man: generate man page from help text of program</summary>
+  <homepage>http://gnuwin32.sourceforge.net/packages/help2man.htm</homepage>
+  <implementation arch="Windows-*" id="sha1new=21b11641e79283ad42b7d8479203c8e4d3c947d9" langs="fr pl" license="GPL v2 (GNU General Public License)" released="2005-04-24" version="1.35.1">
+    <requires interface="http://repo.roscidus.com/devel/gettext">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <command name="run" path="bin\help2man">
+      <runner interface="http://repo.roscidus.com/perl/perl">
+        <arg>-w</arg>
+      </runner>
+    </command>
+    <manifest-digest sha256new="EHCF2JPW23VUGWVBIFS4U3WBMNRSBAQIVUSB7YVS4YUDUQ364KTQ"/>
+    <archive href="https://sourceforge.net/projects/gnuwin32/files/help2man/1.35.1/help2man-1.35.1-bin.zip" size="41013" type="application/zip"/>
+    <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/help2man-bin.zip?raw=true" size="41013" type="application/zip"/>
+  </implementation>
+  <package-implementation distributions="Gentoo" package="sys-apps/help2man"/>
+  <package-implementation package="help2man"/>
+  <entry-point binary-name="help2man" command="run">
+    <needs-terminal/>
+  </entry-point>
+</interface>


### PR DESCRIPTION
Add gnuwin32 package of help2man.

This is a broadly supported project with 136 packages in 111 repos.

This is part of 0install/0install.de-feeds#3

Moved from https://github.com/0install/repo.roscidus.com/pull/211