### PR TITLE
iconv package hash changed

### DIFF
--- a/lib/libiconv.xml
+++ b/lib/libiconv.xml
@@ -12,14 +12,13 @@
   <homepage>http://gnuwin32.sourceforge.net/packages/libiconv.htm</homepage>
   <needs-terminal/>
   <group arch="Windows-i486">
-    <implementation id="sha1new=206996fa8ec1a460c1d470e92024a32aba400616" langs="ca da de es et fi fr ga gl hr hu id it nl pl pt_BR ro ru sk sl sr sv tr uk zh_CN" license="GPL v3 (GNU General Public License)" released="2004-10-14" version="1.9.2-1-3">
+    <implementation id="sha1new=580053c4fff5d5b512517f8cfab271440ea44c4b" langs="ca da de es et fi fr ga gl hr hu id it nl pl pt_BR ro ru sk sl sr sv tr uk zh_CN" license="GPL v3 (GNU General Public License)" released="2004-10-14" version="1.9.2-1-3">
       <command name="run" path="bin/iconv.exe">
         <requires interface="https://apps.0install.net/devel/gettext.xml" version="0.14.4-3">
           <environment insert="bin" name="PATH"/>
         </requires>
       </command>
-
-      <manifest-digest sha256new="6WTPZBBK4OTOKXN2NRFDTRHNVEZUUFTAHRLXLBEVHPEDB4NI5J6Q"/>
+      <manifest-digest sha256new="IUGPL7T4UYPJBWUDFEIMEWRVAWTGEYKGAMK5QBNJYOV3225C5R3A" />
       <archive href="https://sourceforge.net/projects/gnuwin32/files/libiconv/1.9.2-1/libiconv-1.9.2-1-bin.zip" size="828380" type="application/zip"/>
       <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/libiconv-bin.zip?raw=true" size="828380" type="application/zip"/>
     </implementation>


### PR DESCRIPTION
The lib iconv hashes changed without the archives being updated.

how could this happen?

findutils will not work without new hashes.