### PR TITLE
windows 0install complains about the gentoo package  readline version restriction

### DIFF
--- a/lib/readline5.xml
+++ b/lib/readline5.xml
@@ -15,6 +15,6 @@ The history facilites are also placed into a separate library, the History libra
     <archive href="https://sourceforge.net/projects/gnuwin32/files/readline/5.0-1/readline-5.0-1-bin.zip" size="443791" type="application/zip"/>
     <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/readline-bin.zip?raw=true" size="443791" type="application/zip"/>
   </implementation>
-  <package-implementation distributions="Gentoo" package="sys-libs/readline" version="5..!6"/>
+  <package-implementation distributions="Gentoo" package="sys-libs/readline"/>
   <package-implementation package="readline"/>
 </interface>


### PR DESCRIPTION
Remove the Gentoo package implementation version restriction since it keeps windows 0install from running.