### PR TITLE
Add Source highlight convert source code to HTML

### DIFF
--- a/utils/source-highlight.xml
+++ b/utils/source-highlight.xml
@@ -24,8 +24,8 @@ as source languages, and
 •XHTML 
 •ANSI color escape sequences 
 </description>
-  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>
-  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.png" type="image/png"/>
+  <icon href="https://raw.githubusercontent.com/0install/apps/master/utils/gnu.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/apps/master/utils/gnu.png" type="image/png"/>
   <category>Utility</category>
   <homepage>http://gnuwin32.sourceforge.net/packages/src-highlite.htm</homepage>
   <needs-terminal/>

--- a/utils/source-highlight.xml
+++ b/utils/source-highlight.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="https://apps.0install.net/utils/source-highlight.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Src-Highlite</name>
+  <summary xml:lang="en">Source-highlight: convert source code to HTML</summary>
+  <description xml:lang="en">This program, given a source file, produces a document with syntax highlighting. At the moment this package can handle 
+•Java 
+•Javascript 
+•C/C++ 
+•Prolog 
+•Perl 
+•Php3 
+•Python 
+•Flex 
+•ChangeLog 
+•Ruby 
+•Lua 
+•Caml 
+•Sml 
+•Log 
+
+as source languages, and 
+•HTML 
+•XHTML 
+•ANSI color escape sequences 
+</description>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.png" type="image/png"/>
+  <category>Utility</category>
+  <homepage>http://gnuwin32.sourceforge.net/packages/src-highlite.htm</homepage>
+  <needs-terminal/>
+  <implementation arch="Windows-*" id="sha1new=5f19d4ada3f9c9c7c11ebceb8be8281b241bfe49" license="GPL v2 (GNU General Public License)" released="2005-11-19" version="2.1.2">
+    <environment insert="share/source-highlight" name="SOURCE_HIGHLIGHT_DATADIR"/>
+    <command name="run" path="bin/source-highlight.exe">
+      <arg>--data-dir=$SOURCE_HIGHLIGHT_DATADIR</arg>
+    </command>
+    <command name="src-hilite-lesspipe" path="bin/src-hilite-lesspipe.sh">
+      <executable-in-path name="source-highlight"/>
+      <runner interface="https://apps.0install.net/utils/bash.xml"/>
+    </command>
+    <command name="cpp2html" path="bin/cpp2html">
+      <executable-in-path name="source-highlight"/>
+      <runner interface="https://apps.0install.net/utils/bash.xml"/>
+    </command>
+    <command name="java2html" path="bin/java2html">
+      <executable-in-path name="source-highlight"/>
+      <runner interface="https://apps.0install.net/utils/bash.xml"/>
+    </command>
+    <manifest-digest sha256new="VTJWGBSYT7K3BW7FMNX23HR44CWFH3JYER3GY5W5R7EG5D3NWP6Q"/>
+    <archive href="https://sourceforge.net/projects/gnuwin32/files/src-highlite/2.1.2/src-highlite-2.1.2-bin.zip" size="325628" type="application/zip"/>
+    <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/src-highlite-bin.zip?raw=true" size="325628" type="application/zip"/>
+  </implementation>
+  <package-implementation distributions="Gentoo" package="dev-util/source-highlight"/>
+  <package-implementation package="source-highlight"/>
+  <entry-point binary-name="source-highlight" command="run">
+    <needs-terminal/>
+    <name xml:lang="en">source-highlight</name>
+    <summary xml:lang="en">Highlight the syntax of a source file (e.g. Java) into a specific format (e.g.  HTML)</summary>
+  </entry-point>
+  <entry-point binary-name="src-hilite-lesspipe" command="src-hilite-lesspipe">
+    <needs-terminal/>
+    <name xml:lang="en">src-hilite-lesspipe</name>
+  </entry-point>
+  <entry-point binary-name="cpp2html" command="cpp2html">
+    <needs-terminal/>
+    <name xml:lang="en">cpp2html</name>
+  </entry-point>
+  <entry-point binary-name="java2html" command="java2html">
+    <needs-terminal/>
+    <name xml:lang="en">java2html</name>
+  </entry-point>
+</interface>
+


### PR DESCRIPTION
 Add gnuwin32 package of source-highlight.

This is a supported project with 110 packages across 92 repos on repology.

This is part of 0install/0install.de-feeds#3

