### PR TITLE
Add Hp2xx, convert HP-GL plotter language files

### DIFF
--- a/utils/hp2xx.xml
+++ b/utils/hp2xx.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="https://apps.0install.net/utils/hp2xx.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Hp2xx</name>
+  <summary xml:lang="en">Hp2xx: convert HP-GL plotter language files</summary>
+  <description xml:lang="en">The hp2xx program is a versatile tool to convert vector-oriented graphics data given in Hewlett-Packard's HP-GL plotter language into a variety of popular graphics formats, both vector- and raster-oriented. 
+
+The various supported output formats include Encapsulated PostScript (EPS), PCX, IMG, and several formats intended to facilitate the generation of graphics within TeX documents. In addition, hp2xx output is printable on the HP Laserjet/ Deskjet printer series, and it may be used as a HP-GL previewer on many platforms, e.g., X11 and DOS (VGA). 
+
+hp2xx first converts all HP-GL data into pure vectors and buffers them internally. It then converts these vectors into a specified output format (vector modes), or rasterizes them (raster modes) on an internal bitmap. In raster modes, hp2xx then translates the bitmap into the output format. 
+</description>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.png" type="image/png"/>
+  <category>Graphics</category>
+  <homepage>http://gnuwin32.sourceforge.net/packages/hp2xx.htm</homepage>
+  <needs-terminal/>
+  <implementation arch="Windows-*" id="sha1new=de2f069f4d3e99bc32c4a356472a716b7f0e1a60" license="GPL v2 (GNU General Public License)" released="2005-05-14" version="3.4.4-2" version-modifier="-3">
+    <requires interface="https://apps.0install.net/lib/jpeg.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/png12-0.xml" version="1.2.8..!1.2.37">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/tiff.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/pdfliblight.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/zlib.xxml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <command name="run" path="bin/hp2xx.exe"/>
+    <manifest-digest sha256new="EADBVODLCAFMSE4HTMIRFE7GAE2TCOEIJVZHEQC7UHY5GFRXRBCA"/>
+    <archive href="https://sourceforge.net/projects/gnuwin32/files/hp2xx/3.4.4-2/hp2xx-3.4.4-2-bin.zip" size="193871" type="application/zip"/>
+    <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/hp2xx-bin.zip?raw=true" size="193871" type="application/zip"/>
+  </implementation>
+  <package-implementation distributions="Gentoo" package="media-gfx/hp2xx"/>
+  <package-implementation package="hp2xx"/>
+  <entry-point binary-name="hp2xx" command="run">
+    <needs-terminal/>
+  </entry-point>
+</interface>
+

--- a/utils/hp2xx.xml
+++ b/utils/hp2xx.xml
@@ -9,8 +9,8 @@ The various supported output formats include Encapsulated PostScript (EPS), PCX,
 
 hp2xx first converts all HP-GL data into pure vectors and buffers them internally. It then converts these vectors into a specified output format (vector modes), or rasterizes them (raster modes) on an internal bitmap. In raster modes, hp2xx then translates the bitmap into the output format. 
 </description>
-  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>
-  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.png" type="image/png"/>
+  <icon href="https://raw.githubusercontent.com/0install/apps/master/utils/gnu.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/apps/master/utils/gnu.png" type="image/png"/>
   <category>Graphics</category>
   <homepage>http://gnuwin32.sourceforge.net/packages/hp2xx.htm</homepage>
   <needs-terminal/>


### PR DESCRIPTION
 Add gnuwin32 package of hp2xx.

This is a supported project with 52 packages in 47 repos.

This package depends on the feed packages pdfliblight #148, jpeg & tiff #85 

This is part of 0install/0install.de-feeds#3

