### PR TITLE
Add png 1.6 feed

### DIFF
--- a/lib/png16-0.watch.py
+++ b/lib/png16-0.watch.py
@@ -1,0 +1,47 @@
+"""
+    libpng v1.6 0watch script for packages from the mingw64 project
+"""
+from os.path import abspath, join, dirname
+import sys
+sys.path.insert(0, abspath(join(dirname(__file__), '..')))
+from mingw64watch import get_new_version, \
+                         get_mingw64_valid_new_package_item_map, \
+                         get_mingw32_valid_new_package_item_map  # noqa: E402
+
+NAME = 'libpng'
+FEED = 'png16-0.xml'
+
+PKG_MAP_64 = get_mingw64_valid_new_package_item_map(NAME, FEED)
+RELEASE64 = get_new_version(PKG_MAP_64)
+
+PKG_MAP_32 = get_mingw32_valid_new_package_item_map(NAME, FEED)
+RELEASE32 = get_new_version(PKG_MAP_32)
+
+if RELEASE64 is None and RELEASE32 is None:
+    exit()
+
+if RELEASE64 is None or RELEASE32 is None:
+    MSG = f"either the 32 or the 64 bit release is not ready for packaging"
+    raise Exception(MSG)
+
+if RELEASE64['version'] != RELEASE32['version']:
+    raise Exception(f"""64bit version {RELEASE64['version']} does not match
+                        32bit version {RELEASE32['version']}""")
+
+if RELEASE64['license'] != RELEASE32['license']:
+    raise Exception(f"""64bit license {RELEASE64['license']} does not match
+                        32bit license {RELEASE32['license']}""")
+
+if RELEASE64['packager'] != RELEASE32['packager']:
+    raise Exception(f"""64bit packager {RELEASE64['packager']} does not match
+                        32bit packager {RELEASE32['packager']}""")
+
+if RELEASE64['desc'] != RELEASE32['desc']:
+    raise Exception(f"""64bit description {RELEASE64['desc']} does not match
+                        32bit description {RELEASE32['desc']}""")
+
+RELEASE64['released32'] = RELEASE32['released']
+RELEASE64['pkg_url32'] = RELEASE32['pkg_url']
+
+releases = [RELEASE64]
+# print(releases)

--- a/lib/png16-0.xml
+++ b/lib/png16-0.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="https://apps.0install.net/lib/png16-0.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>libpng16-0</name>
+  <summary>A collection of routines used to create PNG format graphics</summary>
+  <description>libpng is a library implementing an interface for reading and writing
+PNG (Portable Network Graphics) format files.
+
+This package contains the runtime library files needed to run software
+using libpng.</description>
+  <category>Graphics</category>
+  <homepage>http://www.libpng.org/pub/png/libpng.html</homepage>
+  <needs-terminal/>
+  <package-implementation package="libpng" />
+  <package-implementation package="libpng16-0"/>
+  <package-implementation package="libpng16"/>
+  <package-implementation package="media-libs/libpng" distributions="Gentoo" />
+  <package-implementation package="libpng1.6" distributions="Debian" />
+  <package-implementation package="graphics/png" distributions="Ports" />
+  <group license="zlib/libpng License">
+    <requires interface="https://apps.0install.net/lib/gcc-libs.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/zlib.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <command name="run" path="bin/pngfix.exe"/>
+  
+    <command name="png-fix-itxt" path="bin/png-fix-itxt.exe"/>
+  
+    <command name="libpng16-config" path="bin/libpng16-config"/>
+  
+    <command name="libpng-config" path="bin/libpng-config"/>
+  
+    <group released="2018-12-03" version="1.6.36-1">
+      <implementation arch="Windows-x86_64" id="sha1new=e3c20cee2dff3e6330542739374811f680da0c96">
+        <archive extract="mingw64" href="http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libpng-1.6.36-1-any.pkg.tar.xz" size="298024"/>
+      </implementation>
+      <implementation arch="Windows-i686" id="sha1new=8944d6543025943fbaf6c501cc5070cb71ca3707">
+        <archive extract="mingw32" href="http://repo.msys2.org/mingw/i686/mingw-w64-i686-libpng-1.6.36-1-any.pkg.tar.xz" size="300048"/>
+      </implementation>
+    </group>
+    <group version="1.6.37-3">
+      <dc:creator>Alexey Pavlov &lt;alexpux@gmail.com&gt;</dc:creator>
+      <implementation arch="Windows-x86_64" id="sha1new=0d1541417b6859b9e1b2543e03875c678b9d2271" released="2020-05-06">
+        <dc:available>2019-04-23</dc:available>
+	<manifest-digest sha256new="3XMBWJUUBNLOTACQ3VXF6XRDTCVTZW6QHRCKPZN4LRHYYVBLNZ4A"/>
+      <archive extract="mingw64" href="http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libpng-1.6.37-3-any.pkg.tar.xz" size="355436"/>
+      </implementation>
+      <implementation arch="Windows-i686" id="sha1new=613bb705b38ebd634991de362b94ef00db50dc8d" released="2020-05-06">
+        <dc:available>2019-04-23</dc:available>
+	<manifest-digest sha256new="BKBOVWAUP5DDGSFQYCYEJRNZM4J5T4Z6W352UCSPF56X7HTGNZLQ"/>
+        <archive extract="mingw32" href="http://repo.msys2.org/mingw/i686/mingw-w64-i686-libpng-1.6.37-3-any.pkg.tar.xz" size="355156"/>
+      </implementation>
+    </group>
+  </group>
+
+    <entry-point binary-name="pngfix" command="run">
+  <needs-terminal/>
+    <name>pngfix</name>
+    <summary xml:lang="en">Tests, optimizes and optionally fixes the zlib header in PNG files.</summary>
+    </entry-point>
+  
+    <entry-point binary-name="png-fix-itxt" command="png-fix-itxt">
+  <needs-terminal/>
+        <name>png-fix-itxt</name>
+    	<summary xml:lang="en">Fixes a PNG file written with libpng-1.6.0 or 1.6.1 that has one or more uncompressed iTXt chunks.</summary>
+    </entry-point>
+
+</interface>
+

--- a/lib/png16-0.xml.template
+++ b/lib/png16-0.xml.template
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>{name}</name>
+  <summary>{desc}</summary>
+  <description>libpng is a library implementing an interface for reading and writing
+PNG (Portable Network Graphics) format files.
+
+This package contains the runtime library files needed to run software
+using libpng.</description>
+  <category>Graphics</category>
+  <homepage>{url}</homepage>
+  <needs-terminal/>
+
+  <group license="{license}">
+    <requires interface="https://apps.0install.net/lib/gcc-libs.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/zlib.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <command name="run" path="bin/pngfix.exe"/>
+
+    <command name="png-fix-itxt" path="bin/png-fix-itxt.exe"/>
+
+    <command name="libpng16-config" path="bin/libpng16-config"/>
+
+    <command name="libpng-config" path="bin/libpng-config"/>
+
+    <group version="{version}">
+      <dc:creator>{packager}</dc:creator>
+      <implementation arch="Windows-x86_64">
+        <dc:available>{released}</dc:available>
+	<manifest-digest/>
+      <archive extract="mingw64" href="{pkg_url}"/>
+      </implementation>
+      <implementation arch="Windows-i686">
+        <dc:available>{released32}</dc:available>
+	<manifest-digest/>
+        <archive extract="mingw32" href="{pkg_url32}"/>
+      </implementation>
+    </group>
+  </group>
+
+
+
+  <feed-for interface="https://apps.0install.net/lib/png16-0.xml"/>
+</interface>
+


### PR DESCRIPTION
Add mingw png 1.6 feed

This is a dependency of optipng, pngcrush, and pngnq

This feed depends on the mingw gcc-libs #158   and zlib #159  feeds

This is part of https://github.com/0install/0install.de-feeds/issues/3