### PR TITLE
Add Pngnq,  a tool for quantizing PNG images in RGBA format

### DIFF
--- a/utils/pngnq.watch.py
+++ b/utils/pngnq.watch.py
@@ -1,0 +1,47 @@
+"""
+    pngnq 0watch script for optipng packages from the mingw64 project
+"""
+from os.path import abspath, join, dirname
+import sys
+sys.path.insert(0, abspath(join(dirname(__file__), '..')))
+from mingw64watch import get_new_version, \
+                         get_mingw64_valid_new_package_item_map, \
+                         get_mingw32_valid_new_package_item_map  # noqa: E402
+
+NAME = 'pngnq'
+FEED = 'pngnq.xml'
+
+PKG_MAP_64 = get_mingw64_valid_new_package_item_map(NAME, FEED)
+RELEASE64 = get_new_version(PKG_MAP_64)
+
+PKG_MAP_32 = get_mingw32_valid_new_package_item_map(NAME, FEED)
+RELEASE32 = get_new_version(PKG_MAP_32)
+
+if RELEASE64 is None and RELEASE32 is None:
+    exit()
+
+if RELEASE64 is None or RELEASE32 is None:
+    MSG = f"either the 32 or the 64 bit release is not ready for packaging"
+    raise Exception(MSG)
+
+if RELEASE64['version'] != RELEASE32['version']:
+    raise Exception(f"""64bit version {RELEASE64['version']} does not match
+                        32bit version {RELEASE32['version']}""")
+
+if RELEASE64['license'] != RELEASE32['license']:
+    raise Exception(f"""64bit license {RELEASE64['license']} does not match
+                        32bit license {RELEASE32['license']}""")
+
+if RELEASE64['packager'] != RELEASE32['packager']:
+    raise Exception(f"""64bit packager {RELEASE64['packager']} does not match
+                        32bit packager {RELEASE32['packager']}""")
+
+if RELEASE64['desc'] != RELEASE32['desc']:
+    raise Exception(f"""64bit description {RELEASE64['desc']} does not match
+                        32bit description {RELEASE32['desc']}""")
+
+RELEASE64['released32'] = RELEASE32['released']
+RELEASE64['pkg_url32'] = RELEASE32['pkg_url']
+
+releases = [RELEASE64]
+# print(releases)

--- a/utils/pngnq.xml
+++ b/utils/pngnq.xml
@@ -24,7 +24,7 @@ input file name extended with &quot;-nq8.png&quot; or a specified extension.
       <environment insert="bin" name="PATH"/>
     </requires>
     <command name="run" path="bin/pngnq.exe"/>
-  
+
     <command name="pngcomp" path="bin/pngcomp.exe"/>
     <group released="2015-07-20" version="1.1-2">
       <implementation arch="Windows-x86_64" id="sha1new=9f3cc572679cd3e2ca55992c6a50d293b06bc06c">
@@ -35,11 +35,9 @@ input file name extended with &quot;-nq8.png&quot; or a specified extension.
       </implementation>
     </group>
   </group>
-
   <entry-point binary-name="pngnq" command="run">
     <needs-terminal/>
   </entry-point>
-  
   <entry-point binary-name="pngcomp" command="pngcomp">
     <name>pngcomp</name>
     <summary>This program give some basic statistics about the difference between two images.</summary>
@@ -54,5 +52,4 @@ The use of these statistics is limited in that they do not contain a model of hu
     </description>
     <needs-terminal/>
   </entry-point>
-  
 </interface>

--- a/utils/pngnq.xml
+++ b/utils/pngnq.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="https://apps.0install.net/utils/pngnq.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>pngnq</name>
+  <summary>Pngnq is a tool for quantizing PNG images in RGBA format</summary>
+  <description>Quantizes a 32-bit RGBA PNG image to an 8 bit RGBA palette PNG 
+using the neuquant algorithm. The output file name is the 
+input file name extended with &quot;-nq8.png&quot; or a specified extension.
+  </description>
+  <category>Graphics</category>
+  <homepage>http://pngnq.sourceforge.net/</homepage>
+  <needs-terminal/>
+  <package-implementation package="pngnq"/>
+  <package-implementation package="graphics/pngnq" distributions="Ports" />
+  <package-implementation package="media-gfx/pngnq" distributions="Gentoo" />
+  <group license="BSD">
+    <requires interface="https://apps.0install.net/lib/gcc-libs.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/png16-0.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/zlib.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <command name="run" path="bin/pngnq.exe"/>
+  
+    <command name="pngcomp" path="bin/pngcomp.exe"/>
+    <group released="2015-07-20" version="1.1-2">
+      <implementation arch="Windows-x86_64" id="sha1new=9f3cc572679cd3e2ca55992c6a50d293b06bc06c">
+        <archive extract="mingw64" href="http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-pngnq-1.1-2-any.pkg.tar.xz" size="42896"/>
+      </implementation>
+      <implementation arch="Windows-i686" id="sha1new=1b4b23b97f42bd8c99cee7fad9a33798c11e2d0d">
+        <archive extract="mingw32" href="http://repo.msys2.org/mingw/i686/mingw-w64-i686-pngnq-1.1-2-any.pkg.tar.xz" size="40172"/>
+      </implementation>
+    </group>
+  </group>
+
+  <entry-point binary-name="pngnq" command="run">
+    <needs-terminal/>
+  </entry-point>
+  
+  <entry-point binary-name="pngcomp" command="pngcomp">
+    <name>pngcomp</name>
+    <summary>This program give some basic statistics about the difference between two images.</summary>
+    <description>This program give some basic statistics about the difference between two images.
+It was created as a measure of various color quantization methods.
+
+The statistics given include individual pixel differences and also
+block statistics averaged over blocks of pixels. The latter is a better measure
+when images have been dithered.
+
+The use of these statistics is limited in that they do not contain a model of human vision.
+    </description>
+    <needs-terminal/>
+  </entry-point>
+  
+</interface>

--- a/utils/pngnq.xml.template
+++ b/utils/pngnq.xml.template
@@ -2,8 +2,8 @@
 <interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
   <name>{name}</name>
   <summary>{desc}</summary>
-  <description>Quantizes a 32-bit RGBA PNG image to an 8 bit RGBA palette PNG 
-using the neuquant algorithm. The output file name is the 
+  <description>Quantizes a 32-bit RGBA PNG image to an 8 bit RGBA palette PNG
+using the neuquant algorithm. The output file name is the
 input file name extended with &quot;-nq8.png&quot; or a specified extension.
   </description>
   <category>Graphics</category>

--- a/utils/pngnq.xml.template
+++ b/utils/pngnq.xml.template
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>{name}</name>
+  <summary>{desc}</summary>
+  <description>Quantizes a 32-bit RGBA PNG image to an 8 bit RGBA palette PNG 
+using the neuquant algorithm. The output file name is the 
+input file name extended with &quot;-nq8.png&quot; or a specified extension.
+  </description>
+  <category>Graphics</category>
+  <homepage>{url}</homepage>
+  <needs-terminal/>
+
+  <group license="{license}">
+    <requires interface="https://apps.0install.net/lib/gcc-libs.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/png16-0.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="https://apps.0install.net/lib/zlib.xml">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <command name="run" path="bin/pngnq.exe"/>
+
+    <command name="pngcomp" path="bin/pngcomp.exe"/>
+    <group version="{version}">
+      <dc:creator>{packager}</dc:creator>
+      <implementation arch="Windows-x86_64">
+        <dc:available>{released}</dc:available>
+	<manifest-digest/>
+      <archive extract="mingw64" href="{pkg_url}"/>
+      </implementation>
+      <implementation arch="Windows-i686">
+        <dc:available>{released32}</dc:available>
+	<manifest-digest/>
+        <archive extract="mingw32" href="{pkg_url32}"/>
+      </implementation>
+    </group>
+  </group>
+
+
+
+  <feed-for interface="https://apps.0install.net/utils/pngnq.xml"/>
+</interface>


### PR DESCRIPTION
Add mingw feed for pngnq

This is a supported project with 71 feeds across 67 repositories

this feed depends on the mingw feeds for zlib #159 , gcc-libs #158 , and png16 #160 

This is part of 0install/0install.de-feeds#3

