### PR TITLE
fix Mingw watch to not fail if we dont trust the key

### DIFF
--- a/mingw64watch.py
+++ b/mingw64watch.py
@@ -127,7 +127,7 @@ def validate_package(url, file_path, md5, sha256, pgp):
         gpg = gnupg.GPG()
         result = gpg.verify_file(sig, data_filename=file_path, close_file=True)
         trust_level = result.trust_level
-        if trust_level is None or trust_level <= result.TRUST_NEVER:
+        if trust_level is None or result.status != 'signature valid':
             raise Exception(f"Invalid pgp signature for file!")
         print(f'{path} has valid pgp signature')
         validated = True


### PR DESCRIPTION
fix for #178 

Dont check the trust level, instead if the signature is valid, accept it.