### PR TITLE
libintl git hub achive not the correct version

### DIFF
--- a/devel/libintl.xml
+++ b/devel/libintl.xml
@@ -8,9 +8,8 @@
   <icon href="https://raw.githubusercontent.com/0install/apps/master/utils/gnu.png" type="image/png"/>
   <category>Development</category>
   <homepage>http://gnuwin32.sourceforge.net/packages/libintl.htm</homepage>
-  <implementation arch="Windows-i486" version="0.11" released="2005-05-07" license="GPL v2 (GNU General Public License), LGPL (GNU Lesser General Public License)" id="sha1new=ba614f2b9390ac86104effe4413da0ffc7e862d4">
-    <manifest-digest sha256new="E2PTDDUD72FYESRQ6QAG6QD2MCOEGKW2FZKNRQYV7UREY6X4WJYA"/>
-    <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/libintl-bin.zip?raw=true" size="394081" type="application/zip"/>
+  <implementation arch="Windows-i486" version="0.11" released="2005-05-07" license="GPL v2 (GNU General Public License), LGPL (GNU Lesser General Public License)" id="sha1new=ccc56a94a1a473fd127b9a39d2b29445c84e16f7">
+    <manifest-digest sha256new="U6G3MSVDLNBLPULTDOYAU5ZIPK5U4C23ABCTXWFWATWNL3XEDW5Q"/>
     <archive href="https://sourceforge.net/projects/gnuwin32/files/libintl/0.11.5-2/libintl-0.11.5-2-bin.zip" size="190842" type="application/zip"/>
   </implementation>
   <package-implementation distributions="Gentoo" package="dev-libs/libintl"/>


### PR DESCRIPTION
remove github archive of libintl because it is of a different version
update the hashes