### PR TITLE
repace ?raw=true for the as invoker manifest

### DIFF
--- a/devel/freetype.xml
+++ b/devel/freetype.xml
@@ -35,11 +35,11 @@ Note that FreeType is a font service and doesn't provide APIs to perform higher-
     <manifest-digest sha256new="SSHVFITQ7ILNPH4H27EF36GGP47NWATCXNSQRTNA3FEEHFG5SA2Q"/>
     <recipe>
       <archive href="https://sourceforge.net/projects/gnuwin32/files/freetype/2.3.5-1/freetype-2.3.5-1-bin.zip" size="1030605" type="application/zip"/>
-      <file dest="bin/ftpatchk.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
+      <file dest="bin/ftpatchk.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
     </recipe>
     <recipe>
       <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/freetype-bin.zip?raw=true" size="1030605" type="application/zip"/>
-      <file dest="bin/ftpatchk.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
+      <file dest="bin/ftpatchk.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
     </recipe>
   </implementation>
   <entry-point binary-name="ftview" command="run">

--- a/devel/patch.xml
+++ b/devel/patch.xml
@@ -14,11 +14,11 @@
     <manifest-digest sha256new="CFQB26PQ6GT4JJ4QZYUNXU7NLLY6JY4AE5RQOYTLPVUWBFVYKL5Q"/>
     <recipe>
       <archive href="https://sourceforge.net/projects/gnuwin32/files/patch/2.5.9-7/patch-2.5.9-7-bin.zip" size="126248" type="application/zip"/>
-      <file dest="bin/patch.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
+      <file dest="bin/patch.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
     </recipe>
     <recipe>
       <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/patch-bin.zip?raw=true" size="126248" type="application/zip"/>
-      <file dest="bin/patch.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
+      <file dest="bin/patch.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
     </recipe>
   </implementation>
   <package-implementation distributions="Gentoo" package="sys-devel/patch"/>

--- a/utils/coreutils.xml
+++ b/utils/coreutils.xml
@@ -126,15 +126,15 @@
       <manifest-digest sha256new="JXJRWRNPMOKCFMTUN3DPIS2FKGC74CVN5NNQFN4VPU53BP5YQVWQ"/>
       <recipe>
         <archive href="https://sourceforge.net/projects/gnuwin32/files/coreutils/5.3.0/coreutils-5.3.0-bin.zip" size="5176996" type="application/zip"/>
-        <file dest="bin/dircolors.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
-        <file dest="bin/install.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
-        <file dest="bin/ginstall.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
+        <file dest="bin/dircolors.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
+        <file dest="bin/install.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
+        <file dest="bin/ginstall.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
       </recipe>
       <recipe>
         <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/coreutils-bin.zip?raw=true" size="5176996" type="application/zip"/>
-        <file dest="bin/dircolors.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
-        <file dest="bin/install.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
-        <file dest="bin/ginstall.exe.manifest" href="https://github.com/MiKTeX/miktex/blob/master/Resources/Manifests/asInvoker.manifest?raw=true" size="380"/>
+        <file dest="bin/dircolors.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
+        <file dest="bin/install.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
+        <file dest="bin/ginstall.exe.manifest" href="https://raw.githubusercontent.com/MiKTeX/miktex/next/Resources/Manifests/asInvoker.manifest" size="380"/>
       </recipe>
     </implementation>
   </group>


### PR DESCRIPTION
github no longer resolves the current path for the manifest file correctly
this pull request changes the feeds that use it to  have a new path that works