### PR TITLE
Expose corepack command in node package

### DIFF
--- a/javascript/node-darwin.xml.template
+++ b/javascript/node-darwin.xml.template
@@ -14,12 +14,16 @@
   <group license="MIT License">
     <environment insert="lib/node_modules/npm/bin/npm-cli.js" mode="replace" name="NPM_CLI_JS"/>
     <environment insert="lib/node_modules/npm/bin/npx-cli.js" mode="replace" name="NPX_CLI_JS"/>
+    <environment insert="lib/node_modules/corepack/dist/corepack.js" mode="replace" name="COREPACK_CLI_JS"/>
     <command name="run" path="bin/node"/>
     <command name="npm" path="bin/node">
       <arg>$NPM_CLI_JS</arg>
     </command>
     <command name="npx" path="bin/node">
       <arg>$NPX_CLI_JS</arg>
+    </command>
+    <command name="corepack" path="bin/node">
+      <arg>$COREPACK_CLI_JS</arg>
     </command>
 
     <implementation arch="Darwin-x86_64" version="{version}" stability="{stability}" released="{released}">

--- a/javascript/node-linux.xml.template
+++ b/javascript/node-linux.xml.template
@@ -14,12 +14,16 @@
   <group license="MIT License">
     <environment insert="lib/node_modules/npm/bin/npm-cli.js" mode="replace" name="NPM_CLI_JS"/>
     <environment insert="lib/node_modules/npm/bin/npx-cli.js" mode="replace" name="NPX_CLI_JS"/>
+    <environment insert="lib/node_modules/corepack/dist/corepack.js" mode="replace" name="COREPACK_CLI_JS"/>
     <command name="run" path="bin/node"/>
     <command name="npm" path="bin/node">
       <arg>$NPM_CLI_JS</arg>
     </command>
     <command name="npx" path="bin/node">
       <arg>$NPX_CLI_JS</arg>
+    </command>
+    <command name="corepack" path="bin/node">
+      <arg>$COREPACK_CLI_JS</arg>
     </command>
 
     <implementation arch="Linux-x86_64" version="{version}" stability="{stability}" released="{released}">

--- a/javascript/node-windows.xml.template
+++ b/javascript/node-windows.xml.template
@@ -14,12 +14,16 @@
   <group license="MIT License">
     <environment insert="node_modules/npm/bin/npm-cli.js" mode="replace" name="NPM_CLI_JS"/>
     <environment insert="node_modules/npm/bin/npx-cli.js" mode="replace" name="NPX_CLI_JS"/>
+    <environment insert="node_modules/corepack/dist/corepack.js" mode="replace" name="COREPACK_CLI_JS"/>
     <command name="run" path="node.exe"/>
     <command name="npm" path="node.exe">
       <arg>$NPM_CLI_JS</arg>
     </command>
     <command name="npx" path="node.exe">
       <arg>$NPX_CLI_JS</arg>
+    </command>
+    <command name="corepack" path="node.exe">
+      <arg>$COREPACK_CLI_JS</arg>
     </command>
 
     <implementation arch="Windows-x86_64" version="{version}" stability="{stability}" released="{released}">

--- a/javascript/node.xml
+++ b/javascript/node.xml
@@ -25,4 +25,9 @@
     <name>Node Package Executor</name>
     <summary>execute binaries from npm packages</summary>
   </entry-point>
+  <entry-point binary-name="corepack" command="corepack">
+    <needs-terminal/>
+    <name>Corepack</name>
+    <summary>Zero-runtime-dependency package acting as bridge between Node projects and their package managers</summary>
+  </entry-point>
 </interface>


### PR DESCRIPTION
In recent version, Node includes the Corepack utility in its distribution, this exposes the command to users.